### PR TITLE
Replaced MD5 hash with SHA512 base64-encoded

### DIFF
--- a/classes/Login.php
+++ b/classes/Login.php
@@ -78,9 +78,9 @@ class Login
                     // get result row (as an object)
                     $result_row = $result_of_login_check->fetch_object();
 
-                    // using PHP 5.5's password_verify() function to check if the provided password fits
-                    // the hash of that user's password
-                    if (md5($_POST['user_password']) == $result_row->password) {
+                    // Hashes the users password with the SHA512 algorithm and encodes it as base64 for backwards
+                    // with the database
+                    if (base64_encode(hash('sha512', $_POST['user_password'])) == $result_row->password) {
 
                         // write user data into PHP SESSION (a file on your server)
                         $_SESSION['user_id'] = $result_row->id;

--- a/classes/Registration.php
+++ b/classes/Registration.php
@@ -82,10 +82,8 @@ class Registration
 
                 $user_password = $_POST['user_password_new'];
 
-                // crypt the user's password with PHP 5.5's password_hash() function, results in a 60 character
-                // hash string. the PASSWORD_DEFAULT constant is defined by the PHP 5.5, or if you are using
-                // PHP 5.3/5.4, by the password hashing compatibility library
-                $user_password_hash = md5($user_password);
+                // Hashes the user's password with the SHA512 algorithm and encode with base64 for backwards compability
+                $user_password_hash = base64_encode(hash('sha512', $user_password));
 
                 // check if user or email address already exists
                 $sql = "SELECT * FROM accounts WHERE name = '" . $user_name . "' OR email = '" . $user_email . "';";


### PR DESCRIPTION
Changes are made to the hashing to enforce stronger entropy and defense against rainbow table attacks. 

Base64 encoding was added to maintain backwards compability with the database itself.
